### PR TITLE
Add a predefined error uri for network failures.

### DIFF
--- a/spec/advanced.md
+++ b/spec/advanced.md
@@ -2004,7 +2004,9 @@ A *Router* rejected client request to disclose its identity
 
     wamp.error.option_disallowed.disclose_me
 
+A *Router* encountered a network failure
 
+    wamp.error.network_failure
 
 ### Authentication examples
 


### PR DESCRIPTION
For example, when the dealer is processing an incoming call message
from the caller, the dealer has to send an invocation message to the
callee. If there is a network failure when trying to send the
invocation message we need to send an error response back to the
callee so that it can respond accordingly. Otherwise, the caller
will be blocked waiting for an invocation response which will never
arrive.